### PR TITLE
Makefile: don't hardcode pkg-config and CC to gcc.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,14 @@
-CC=gcc
+CC?=gcc
+PKG_CONFIG?=pkg-config
 
 CFLAGS?=-g -O2 -Wall
 LDFLAGS?=
 
-CFLAGS+=`pkg-config x11 --cflags`
-LDFLAGS+=`pkg-config x11 --libs`
+CFLAGS+=`$(PKG_CONFIG) x11 --cflags`
+LDFLAGS+=`$(PKG_CONFIG) x11 --libs`
 
-CFLAGS+=`pkg-config imlib2 --cflags`
-LDFLAGS+=`pkg-config imlib2 --libs`
+CFLAGS+=`$(PKG_CONFIG) imlib2 --cflags`
+LDFLAGS+=`$(PKG_CONFIG) imlib2 --libs`
 
 hsetroot: hsetroot.o outputs_xrandr.o
 


### PR DESCRIPTION
Makes it easier to package for distros like Exherbo that require the host arch before the tool (example: x86_64-pc-linux-gnu-cc i686-pc-linux-gnu-pkg-config)