### PR TITLE
Add AUR git package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,11 @@ PKG_CONFIG?=pkg-config
 CFLAGS?=-g -O2 -Wall
 LDFLAGS?=
 
-CFLAGS+=`$(PKG_CONFIG) x11 --cflags`
-LDFLAGS+=`$(PKG_CONFIG) x11 --libs`
+CFLAGS+=$(shell $(PKG_CONFIG) x11 --cflags)
+LDFLAGS+=$(shell $(PKG_CONFIG) x11 --libs)
 
-CFLAGS+=`$(PKG_CONFIG) imlib2 --cflags`
-LDFLAGS+=`$(PKG_CONFIG) imlib2 --libs`
+CFLAGS+=$(shell $(PKG_CONFIG) imlib2 --cflags)
+LDFLAGS+=$(shell $(PKG_CONFIG) imlib2 --libs)
 
 hsetroot: hsetroot.o outputs_xrandr.o
 

--- a/pkg/arch/PKGBUILD.git
+++ b/pkg/arch/PKGBUILD.git
@@ -1,0 +1,30 @@
+# Contributor: Justin Charette <charetjc at gmail dot com>
+#
+# See http://wiki.archlinux.org/index.php/VCS_PKGBUILD_Guidelines
+# for more information on packaging from GIT sources.
+
+pkgname=himdel-hsetroot-git
+pkgver=1.0.2
+pkgrel=1
+pkgdesc='A tool which allows you to compose wallpapers for X.  A fork of hsetroot by Hyriand.'
+arch=('x86_64')
+url='http://github.com/himdel/hsetroot'
+license=('GPL2')
+depends=('imlib2' 'xorg-server' 'xorg-xrandr')
+makedepends=('git')
+provides=('hsetroot')
+conflicts=('hsetroot')
+source=(git+https://github.com/himdel/hsetroot.git)
+md5sums=('SKIP')
+
+_gitname=hsetroot
+
+build() {
+  cd "${srcdir}/${_gitname}"
+  make
+}
+
+package() {
+  cd "${srcdir}/${_gitname}"
+  install -D hsetroot "${pkgdir}/usr/bin/hsetroot"
+}


### PR DESCRIPTION
Related to issue #1.  I have no plans to add this on [aur.archlinux.org](https://aur.archlinux.org), so anyone is welcome to be the AUR maintainer.

Since there are no tagged releases, I created an AUR package that builds/installs the latest code in the master branch.  Unless the dependencies or `make install` changes, this package should require no maintenance.

In the event @himdel starts tagging releases, a separate `PKGBUILD` can be created at that time to only install the latest release.

I had issues with the backticks in the Makefile not evaluating, so there's a patch to switch over to the shell macro, though I'm not sure which version is considered more "portable".

ArchLinux install instructions:

1.  Download PKGBUILD.git from pkgs/arch
2.  Rename PKGBUILD.git to PKGBUILD
3.  To build the package, run `makepkg -scf` which will create the `.pkg.tar.xz` file.
4.  To install the package, run `sudo pacman -U <file.pkg.tar.xz>`.