### PR TITLE
Fix typo

### DIFF
--- a/hsetroot.c
+++ b/hsetroot.c
@@ -36,7 +36,7 @@ usage(char *commandline)
     " -tile <image>              Render an image tiled\n"
     " -full <image>              Render an image maximum aspect\n"
     " -extend <image>            Render an image max aspect and fill borders\n"
-    " -fill <image>              Render an image strechted\n"
+    " -fill <image>              Render an image stretched\n"
     "\n"
     "Manipulations:\n"
     " -tint <color>              Tint the current image\n"


### PR DESCRIPTION
Under the `Image files` section in the help page, there was a typo "strechted". I simply corrected it to "stretched" :^)