### PR TITLE
parse_color - use XParseColor to support more color formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ This repo contains hsetroot 1.0.2 with the following changes:
      * Add the '-cover' option
    * reintroduced the screen mask `-screens` option from earlier versions .. which is rather useless actually, as it deals with X screens, not xrandr outputs
    * **added output support for all modes**, using xinerama
+   * added support for color names and more color formats (using XParseColor except for #rrggbbaa)


### PR DESCRIPTION
until now, hsetroot only supported #rrggbb and #rrggbbaa

XParseColor understands #000, #000000, rgb:0/0/0, black
but not #rrggbbaa - using sscanf to deal with the aa part ourselves

Fixes https://github.com/himdel/hsetroot/issues/15