### PR TITLE
Avoid taking a reference to a variable that dies right away.

### DIFF
--- a/hsetroot.c
+++ b/hsetroot.c
@@ -271,13 +271,14 @@ main(int argc, char **argv)
   int noutputs = 0;
   XineramaScreenInfo *outputs = NULL;
 
+  XineramaScreenInfo fake = {
+    .x_org = 0,
+    .y_org = 0,
+    .width = 0,
+    .height = 0,
+  };
+
   if (opt_root) {
-    XineramaScreenInfo fake = {
-      .x_org = 0,
-      .y_org = 0,
-      .width = 0,
-      .height = 0,
-    };
     noutputs = 1;
     outputs = &fake;
   } else {


### PR DESCRIPTION
`outputs` was being set to the address of a variable that went out of scope right after, causing the origin to be set differently to 0, 0 when using `-root`.