### PR TITLE
[RFC] Set the default alpha value to 0

### DIFF
--- a/hsetroot.c
+++ b/hsetroot.c
@@ -314,13 +314,13 @@ main(int argc, char **argv)
     image = imlib_create_image(width, height);
     imlib_context_set_image(image);
 
-    imlib_context_set_color(0, 0, 0, 255);
+    imlib_context_set_color(0, 0, 0, 0);
     imlib_image_fill_rectangle(0, 0, width, height);
 
     imlib_context_set_dither(1);
     imlib_context_set_blend(1);
 
-    alpha = 255;
+    alpha = 0;
 
     for (i = 1; i < argc; i++) {
       if (modifier != NULL) {


### PR DESCRIPTION
**I am aware that this PR changes the default behavior, therefore it is an RFC only - please share your thoughts**

### The problem:
When using Compton/Picom, one can not use xsetroot to change the background and hsetroot is needed (more details [here](https://github.com/chjj/compton/issues/162)). However, when setting the background with hsetroot, even in the very top of .xinitrc, there still is a short blink of gray on fast-loading systems. This behavior does not occur with xsetroot, as the initial/default color is black.

### The solution in this commit:
Set the default alpha value from 255 to 0, so that the initial/default color will be black as well, thus mimicing the behavior of xsetroot.