### PR TITLE
Don't draw outside screen bounds in Cover mode

### DIFF
--- a/hsetroot.c
+++ b/hsetroot.c
@@ -175,8 +175,13 @@ load_image(ImageMode mode, const char *arg, int alpha, Imlib_Image rootimg, Xine
 
       int top = (o.height - (int) (imgH * aspect)) / 2;
       int left = (o.width - (int) (imgW * aspect)) / 2;
+      int iwidth = (int) (o.width / aspect);
+      int iheight = (int) (o.height / aspect);
 
-      imlib_blend_image_onto_image(buffer, 0, 0, 0, imgW, imgH, o.x_org + left, o.y_org + top, (int) (imgW * aspect), (int) (imgH * aspect));
+      if (mode == Cover)
+        imlib_blend_image_onto_image(buffer, 0, (imgW - iwidth) / 2, (imgH - iheight) / 2, iwidth, iheight, o.x_org, o.y_org, o.width, o.height);
+      else
+        imlib_blend_image_onto_image(buffer, 0, 0, 0, imgW, imgH, o.x_org + left, o.y_org + top, (int) (imgW * aspect), (int) (imgH * aspect));
 
       if (mode == Xtend) {
         int w;

--- a/hsetroot.c
+++ b/hsetroot.c
@@ -7,6 +7,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+
 
 typedef enum { Full, Fill, Center, Tile, Xtend, Cover } ImageMode;
 
@@ -169,12 +171,9 @@ load_image(ImageMode mode, const char *arg, int alpha, Imlib_Image rootimg, Xine
     if (mode == Fill) {
       imlib_blend_image_onto_image(buffer, 0, 0, 0, imgW, imgH, o.x_org, o.y_org, o.width, o.height);
     } else if (mode == Cover) {
-      double aspect = ((double) o.width) / imgW;
-      if ((int) (imgH * aspect) < o.height)
-        aspect = (double) o.height / (double) imgH;
-
-      int iwidth = (int) (o.width / aspect);
-      int iheight = (int) (o.height / aspect);
+      // Height and width of the portion of the image to use
+      int iwidth = MIN(imgW, imgH * o.width / o.height);
+      int iheight = MIN(imgH, imgW * o.height / o.width);
 
       imlib_blend_image_onto_image(buffer, 0, (imgW - iwidth) / 2, (imgH - iheight) / 2, iwidth, iheight, o.x_org, o.y_org, o.width, o.height);
     } else if ((mode == Full) || (mode == Xtend)) {

--- a/hsetroot.c
+++ b/hsetroot.c
@@ -168,20 +168,24 @@ load_image(ImageMode mode, const char *arg, int alpha, Imlib_Image rootimg, Xine
 
     if (mode == Fill) {
       imlib_blend_image_onto_image(buffer, 0, 0, 0, imgW, imgH, o.x_org, o.y_org, o.width, o.height);
-    } else if ((mode == Full) || (mode == Xtend) || (mode == Cover)) {
+    } else if (mode == Cover) {
       double aspect = ((double) o.width) / imgW;
-      if (((int) (imgH * aspect) > o.height) != /*xor*/ (mode == Cover))
+      if ((int) (imgH * aspect) < o.height)
+        aspect = (double) o.height / (double) imgH;
+
+      int iwidth = (int) (o.width / aspect);
+      int iheight = (int) (o.height / aspect);
+
+      imlib_blend_image_onto_image(buffer, 0, (imgW - iwidth) / 2, (imgH - iheight) / 2, iwidth, iheight, o.x_org, o.y_org, o.width, o.height);
+    } else if ((mode == Full) || (mode == Xtend)) {
+      double aspect = ((double) o.width) / imgW;
+      if ((int) (imgH * aspect) > o.height)
         aspect = (double) o.height / (double) imgH;
 
       int top = (o.height - (int) (imgH * aspect)) / 2;
       int left = (o.width - (int) (imgW * aspect)) / 2;
-      int iwidth = (int) (o.width / aspect);
-      int iheight = (int) (o.height / aspect);
 
-      if (mode == Cover)
-        imlib_blend_image_onto_image(buffer, 0, (imgW - iwidth) / 2, (imgH - iheight) / 2, iwidth, iheight, o.x_org, o.y_org, o.width, o.height);
-      else
-        imlib_blend_image_onto_image(buffer, 0, 0, 0, imgW, imgH, o.x_org + left, o.y_org + top, (int) (imgW * aspect), (int) (imgH * aspect));
+      imlib_blend_image_onto_image(buffer, 0, 0, 0, imgW, imgH, o.x_org + left, o.y_org + top, (int) (imgW * aspect), (int) (imgH * aspect));
 
       if (mode == Xtend) {
         int w;


### PR DESCRIPTION
Currently the Cover mode draws outside the bounds of an XRandR screen, potentially over top of part of a different screen which was already drawn, leading to not-very-pretty overlap.  Instead, figure out what portion of the image to use and draw only within the bounds of the screen.

(Aside: it looks like Tile mode is also guilty of this, and Center if the image is large enough.)

In three commits so you can take whatever part you like - the first one fixes the issue, and the others do some cleanup while we're in the area.