### PR TITLE
Set clipping region to current display

### DIFF
--- a/hsetroot.c
+++ b/hsetroot.c
@@ -165,6 +165,7 @@ load_image(ImageMode mode, const char *arg, int alpha, Imlib_Image rootimg, Xine
   for (int i = 0; i < noutputs; i++) {
     XineramaScreenInfo o = outputs[i];
     printf("output %d: size(%d, %d) pos(%d, %d)\n", i, o.width, o.height, o.x_org, o.y_org);
+    imlib_context_set_cliprect(o.x_org, o.y_org, o.width, o.height);
 
     if (mode == Fill) {
       imlib_blend_image_onto_image(buffer, 0, 0, 0, imgW, imgH, o.x_org, o.y_org, o.width, o.height);


### PR DESCRIPTION
Drawing outside the rectangle of the current display might draw over the
background of another display.  This could happen in Cover, Center, or
Tile mode.  To prevent this, set the clipping region before drawing the
background on each display; then we won't have to do anything
complicated later on.