### PR TITLE
fix macOS compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,11 @@ PREFIX?=/usr/local
 #LDFLAGS+=-Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now
 
 # arch & debian hardening workaround
-LDFLAGS+=-Wl,--no-as-needed
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+	LDFLAGS+=-Wl,--no-as-needed
+endif
+
 
 CFLAGS+=$(shell $(PKG_CONFIG) x11 --cflags)
 LDFLAGS+=$(shell $(PKG_CONFIG) x11 --libs)


### PR DESCRIPTION
On macOS ld doesn't have the --no-as-needed option
```
ld: unknown option: --no-as-needed
clang: error: linker command failed with exit code 1 (use -v to see invocation)
error: command 'clang' failed with exit status 1
```