### PR TITLE
hsr-outputs: Check if display was initialised

### DIFF
--- a/hsr-outputs.c
+++ b/hsr-outputs.c
@@ -47,7 +47,11 @@ enum Format { TEXT, CSV, JSON };
 int
 main(int argc, char **argv)
 {
-	Display *display = XOpenDisplay(NULL);
+	Display *display;
+	if (!(display = XOpenDisplay(NULL))) {
+		fprintf(stderr, "Cannot open X display!\n");
+		exit(123);
+	}
 
 	enum Format format = TEXT;
 	void (*print)(XineramaScreenInfo*) = print_text;


### PR DESCRIPTION
hsr-outputs segfaults when no X display is available. Avoid this by
checking first, and responding like hsetroot does when false.

Signed-off-by: Jeroen Roovers <jer@gentoo.org>