### PR TITLE
Fix atom name used when clearing previous background

### DIFF
--- a/hsetroot.c
+++ b/hsetroot.c
@@ -73,7 +73,7 @@ setRootAtoms(Pixmap pixmap)
   int format;
   unsigned long length, after;
 
-  atom_root = XInternAtom(display, "_XROOTMAP_ID", True);
+  atom_root = XInternAtom(display, "_XROOTPMAP_ID", True);
   atom_eroot = XInternAtom(display, "ESETROOT_PMAP_ID", True);
 
   // doing this to clean up after old background


### PR DESCRIPTION
Inherited from Fluxbox' bsetroot, the atom used to clean previous a
previous background contains a typo: `_XROOTMAP_ID` instead of
`_XROOTPMAP_ID`. This results in the cleaning never done, which I
assume would leak the previous backgrounds.

Checking the Debian archive, only hsetroot, bsetroot, pcmanfm and
spacefm are using `_XROOTMAP_ID`. They all seem to derive from
bsetroot. On the other hand, many software are using `_XROOTPMAP_ID`,
including xscreensaver and fvwm (both written at a time where people
know how all this works).

Fix #35