### PR TITLE
Fix installation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ hsetroot: hsetroot.o
 hsr-outputs: hsr-outputs.o
 
 install: hsetroot hsr-outputs
-	install -st $(DESTDIR)$(PREFIX)/bin/ hsetroot
-	install -st $(DESTDIR)$(PREFIX)/bin/ hsr-outputs
+	install -Dst $(DESTDIR)$(PREFIX)/bin/ hsetroot
+	install -Dst $(DESTDIR)$(PREFIX)/bin/ hsr-outputs
 
 clean:
 	rm -f *.o hsetroot hsr-outputs


### PR DESCRIPTION
Fixes this error:

[    6s] + make install DESTDIR=/home/abuild/rpmbuild/BUILDROOT/hsetroot-1.0.4-0.x86_64
[    6s] install -st /home/abuild/rpmbuild/BUILDROOT/hsetroot-1.0.4-0.x86_64/usr/bin/ hsetroot
[    6s] install: failed to access '/home/abuild/rpmbuild/BUILDROOT/hsetroot-1.0.4-0.x86_64/usr/bin/': No such file or directory
