### PR TITLE
Support per-output -gradient

### DIFF
--- a/hsetroot.c
+++ b/hsetroot.c
@@ -398,7 +398,10 @@ main(int argc, char **argv)
           fprintf (stderr, "Bad angle (%s)\n", argv[i]);
           continue;
         }
-        imlib_image_fill_color_range_rectangle(0, 0, width, height, angle);
+        for (int j = 0 ; j < noutputs; j++) {
+          XineramaScreenInfo o = outputs[j];
+          imlib_image_fill_color_range_rectangle(o.x_org, o.y_org, o.width, o.height, angle);
+        }
       } else if (strcmp(argv[i], "-fill") == 0) {
         if ((++i) >= argc) {
           fprintf(stderr, "Missing image\n");

--- a/hsetroot.c
+++ b/hsetroot.c
@@ -389,12 +389,12 @@ main(int argc, char **argv)
         imlib_context_set_color(c.r, c.g, c.b, c.a);
         imlib_add_color_to_color_range(distance);
       } else if (strcmp(argv[i], "-gradient") == 0) {
-        int angle;
+        double angle;
         if ((++i) >= argc) {
           fprintf(stderr, "Missing angle\n");
           continue;
         }
-        if (sscanf(argv[i], "%i", &angle) == 0) {
+        if (sscanf(argv[i], "%lf", &angle) == 0) {
           fprintf (stderr, "Bad angle (%s)\n", argv[i]);
           continue;
         }


### PR DESCRIPTION
Until now, `-gradient` behaved as if `-root` was always present.

This changes gradient to paint per-output by default, add -root to use the original behavior.

(Note, on higher resoltions, this suffers from the same issues mentioned in #43, #42 and #28 .. but it also makes it possible to use gradient with multiple sub4k screens when only the total dimension is >4096.)


draft: doesn't *quite* work, without -root we try to paint the composite image on each output, and with -root the list of outputs is that, so nothing per-output is happening